### PR TITLE
Change README from namservers to nameservers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ OPERATIONS:
 
 	1) Get the host's addresse (A record).
 
-	2) Get the namservers (threaded).
+	2) Get the nameservers (threaded).
 
 	3) Get the MX record (threaded).
 


### PR DESCRIPTION
I believe this is a typo, and should be nameservers per https://en.wikipedia.org/wiki/Name_server
