### PR TITLE
Output long option is 'output' not 'out'

### DIFF
--- a/dnsenum.pl
+++ b/dnsenum.pl
@@ -122,7 +122,7 @@ GetOptions (	'dnsserver=s'	=>	\$dnsserver,
 		'u|update=s'	=>	\$update,
 		'v|verbose'	=>	\$verbose,
 		'w|whois'	=>	\$whois,
-		'o|out=s'	=>	\$output);
+		'o|output=s'	=>	\$output);
 
 usage() if $help || @ARGV == 0;
 


### PR DESCRIPTION
As per https://github.com/fwaeytens/dnsenum/blob/master/dnsenum.pl#L1402, the long option for `-o` is `--output`, not `'--out` (or your can update the help :) )