### PR TITLE
Use experimental module for smartmatch

### DIFF
--- a/dnsenum.pl
+++ b/dnsenum.pl
@@ -48,6 +48,7 @@
 
 use strict;
 use warnings;#it complains about uninitialized values when it doesn't find address in RR; need to fix later
+no if $] >= 5.018, 'warnings', "experimental::smartmatch";
 use Config;
 use Term::ANSIColor;
 use Getopt::Long;


### PR DESCRIPTION
The smartmatch feature has been introduced in perl but not marked as experimental at the start.
With [perl >= 5.18](https://metacpan.org/pod/release/RJBS/perl-5.18.0/pod/perldelta.pod#The-smartmatch-family-of-features-are-now-experimental), the feature has been marked as experimental and as dnsenum [use it](https://github.com/fwaeytens/dnsenum/blob/master/dnsenum.pl#L698):

```
[...]
if (!($rr->can('address') && $rr->address ~~ @wildcardaddress) && !($rr->name ~~ @wildcardcname))
[...]
```
the following warning appear at each execution:

```
Smartmatch is experimental at ./dnsenum.pl line 698.
```

I've proposed to conditionnaly load https://metacpan.org/pod/experimental module to avoid these warning.